### PR TITLE
Add support for Server Variables and relevant tests in Chai OpenAPI Response Validator

### DIFF
--- a/commonTestResources/exampleOpenApiFiles/valid/serversDefinedDifferently/withServerVariables.yml
+++ b/commonTestResources/exampleOpenApiFiles/valid/serversDefinedDifferently/withServerVariables.yml
@@ -4,30 +4,48 @@ info:
   description: Has server variables
   version: 0.1.0
 servers:
-  - url:  https://test.com:{portVar}
+  - url:  https://test.com:{portVariable}/{pathVariable}
     description: relative server url
     variables:
-      portVar:
+      portVariable:
         enum: 
           - '1234'
           - '5678'
         default: '1234'
         description: variable at end of server path, like port number
-  - url:  https://{subdomainVar}.test.com:{portVar}
+      pathVariable:
+        enum: 
+          - 'defaultPathVariable'
+          - 'nonDefaultPathVariable'
+        default: 'defaultPathVariable'
+        description: a variable defined with the server but used in the path
+  - url:  https://{subdomainVariable}.test.com:{portVariable}/{firstPathVariable}/{secondPathVariable}
     description: relative server url
     variables:
-      subdomainVar: 
+      subdomainVariable: 
         enum:
-          - default 
-          - nondefault
-        default: default
+          - defaultVariable 
+          - nonDefaultVariable
+        default: defaultVariable
         description: variable at start of server path
-      portVar:
+      portVariable:
         enum: 
           - '1234'
           - '5678'
         default: '1234'
         description: variable at end of server path, like port number
+      firstPathVariable:
+        enum: 
+          - 'defaultFirstPathVariable'
+          - 'nonDefaultFirstPathVariable'
+        default: 'defaultPathVariable'
+        description: a variable defined with the server but used in the path
+      secondPathVariable:
+        enum: 
+          - 'defaultSecondPathVariable'
+          - 'nonDefaultSecondPathVariable'
+        default: 'defaultSecondPathVariable'
+        description: a second path variable defined in the server URL
 paths:
   /test/responseBody/string:
     get:

--- a/commonTestResources/exampleOpenApiFiles/valid/serversDefinedDifferently/withServerVariables.yml
+++ b/commonTestResources/exampleOpenApiFiles/valid/serversDefinedDifferently/withServerVariables.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Example OpenApi 3 spec
+  description: Has server variables
+  version: 0.1.0
+servers:
+  - url:  https://test.com:{portVar}
+    description: relative server url
+    variables:
+      portVar:
+        enum: 
+          - '1234'
+          - '5678'
+        default: '1234'
+        description: variable at end of server path, like port number
+  - url:  https://{subdomainVar}.test.com:{portVar}
+    description: relative server url
+    variables:
+      subdomainVar: 
+        enum:
+          - default 
+          - nondefault
+        default: default
+        description: variable at start of server path
+      portVar:
+        enum: 
+          - '1234'
+          - '5678'
+        default: '1234'
+        description: variable at end of server path, like port number
+paths:
+  /test/responseBody/string:
+    get:
+      responses:
+        200:
+          description: Response body should be a string
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/OpenApi3Spec.js
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/OpenApi3Spec.js
@@ -38,7 +38,7 @@ class OpenApi3Spec extends AbstractOpenApiSpec {
 
   getServerUrls() {
     return this.servers().reduce((allServerURLs, server) =>
-      allServerURLs.concat(replaceServerVarsInURLs([server.url], createServerVarMap(server))), 
+      allServerURLs.concat(replaceServerVariablesInURLs([server.url], createServerVariableMap(server))), 
       []
     );
   }
@@ -51,10 +51,8 @@ class OpenApi3Spec extends AbstractOpenApiSpec {
   }
 
   getMatchingServerUrls(pathname) {
-    const matchingServerUrls = this.getServerUrls().filter((URL) => {
-      const result = pathname.startsWith(extractBasePath(URL))
-      return result;
-    }
+    const matchingServerUrls = this.getServerUrls().filter((URL) =>
+      pathname.startsWith(extractBasePath(URL)),
     );
     return matchingServerUrls;
   }
@@ -112,43 +110,43 @@ class OpenApi3Spec extends AbstractOpenApiSpec {
   }
 }
 
-function createServerVarMap(server) {
+function createServerVariableMap(server) {
   if (!server.variables)
     return new Map()
 
-  const serverVarMap = new Map();
-  const serverVars = Object.keys(server.variables);
+  const serverVariableMap = new Map();
+  const serverVariables = Object.keys(server.variables);
 
-  serverVars.forEach(serverVar => {
-    serverVarMap.set(serverVar, server.variables[serverVar].enum);
+  serverVariables.forEach(serverVariable => {
+    serverVariableMap.set(serverVariable, server.variables[serverVariable].enum);
   });
 
-  return serverVarMap;
+  return serverVariableMap;
 }
 
-function replaceServerVarsInURLs (serverURLs, serverVarMap) {
-  if(serverVarMap.size === 0) {
+function replaceServerVariablesInURLs (serverURLs, serverVariableMap) {
+  if(serverVariableMap.size === 0) {
     return serverURLs;
   }
 
   const replacedServerURLs = [];
 
-  const serverVarName = serverVarMap.keys().next().value;
-  const ServerVarEnums = serverVarMap.get(serverVarName);
+  const serverVariableName = serverVariableMap.keys().next().value;
+  const ServerVariableEnums = serverVariableMap.get(serverVariableName);
   
-  serverVarMap.delete(serverVarName);
+  serverVariableMap.delete(serverVariableName);
   
   serverURLs.forEach(serverURL => {
-    ServerVarEnums.forEach(serverVarEnum => {
-      replacedServerURLs.push(replaceServerVarInURL(serverURL, serverVarName, serverVarEnum));
+    ServerVariableEnums.forEach(serverVariableEnum => {
+      replacedServerURLs.push(replaceServerVariableInURL(serverURL, serverVariableName, serverVariableEnum));
     });
   });
 
-  return replaceServerVarsInURLs(replacedServerURLs, serverVarMap);
+  return replaceServerVariablesInURLs(replacedServerURLs, serverVariableMap);
 }
 
-function replaceServerVarInURL (serverURL, serverVar, serverEnum) {
-  return serverURL.replace(new RegExp(`\\{${serverVar}\\}`, 'g'), serverEnum);
+function replaceServerVariableInURL (serverURL, serverVariable, serverEnum) {
+  return serverURL.replace(new RegExp(`\\{${serverVariable}\\}`, 'g'), serverEnum);
 }
 
 module.exports = OpenApi3Spec;

--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/specsDefineServersDifferently.test.js
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/specsDefineServersDifferently.test.js
@@ -494,7 +494,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
     });
   });
 
-  describe('spec uses server variables to define server', () => {
+  describe('spec defines server using server variables', () => {
     before(() => {
       const pathToApiSpec = path.join(
         dirContainingApiSpec,
@@ -508,7 +508,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         status: 200,
         req: {
           method: 'GET',
-          path: 'https://test.com:1234/test/responseBody/string',
+          path: '/defaultPathVariable/test/responseBody/string',
         },
         body: 'valid body (string)',
       };
@@ -528,7 +528,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         status: 200,
         req: {
           method: 'GET',
-          path: 'https://default.test.com:1234/test/responseBody/string',
+          path: '/defaultFirstPathVariable/defaultSecondPathVariable/test/responseBody/string',
         },
         body: 'valid body (string)',
       };
@@ -548,7 +548,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         status: 200,
         req: {
           method: 'GET',
-          path: 'https://nondefault.test.com:5678/test/responseBody/string',
+          path: '/nonDefaultFirstPathVariable/nonDefaultSecondPathVariable/test/responseBody/string',
         },
         body: 'valid body (string)',
       };
@@ -568,7 +568,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         status: 200,
         req: {
           method: 'GET',
-          path: '/nonExistentEndpointPath',
+          path: '/defaultPathVariable/nonExistentEndpointPath',
         },
         body: 'valid body (string)',
       };
@@ -577,13 +577,9 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         const assertion = () => expect(res).to.satisfyApiSpec;
         expect(assertion).to.throw(
           AssertionError,
-          `'/nonExistentEndpointPath' matches servers ${inspect([
-            'https://test.com:1234',
-            'https://test.com:5678',
-            'https://default.test.com:1234',
-            'https://default.test.com:5678',
-            'https://nondefault.test.com:1234',
-            'https://nondefault.test.com:5678',
+          `'/defaultPathVariable/nonExistentEndpointPath' matches servers ${inspect([
+            'https://test.com:1234/defaultPathVariable',
+            'https://test.com:5678/defaultPathVariable',
           ])} but no <server/endpointPath> combinations`,
         );
       });


### PR DESCRIPTION
I believe this PR resolves https://github.com/RuntimeTools/OpenAPIValidators/issues/89, by adding support for server variables. I have added all tests and code for the Chai plugin - the Jest plugin is still TODO at this stage, although now the code is written it should be very easy to port across.

@Nitwel - can you confirm this resolves the issue for you?