### PR TITLE
chore: release 0.11.0

### DIFF
--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.10.0",
-  "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
+  "version": "0.11.0",
+  "description": "Use Chai to assert that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-openapi",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Jest matchers for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
**chai-openapi-response-validator** and **jest-openapi**

chore:
* switch license from Apache to MIT https://github.com/openapi-library/OpenAPIValidators/pull/211 @rwalle61 