### PR TITLE
Improve TypeScript (no implicit any)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,7 +11,7 @@ env:
 extends:
   - eslint:recommended
   - airbnb-typescript/base
-  # - plugin:@typescript-eslint/recommended
+  - plugin:@typescript-eslint/recommended
   # - plugin:@typescript-eslint/recommended-requiring-type-checking
   - prettier/@typescript-eslint
   - prettier # must go last, to turn off some previous rules

--- a/packages/chai-openapi-response-validator/lib/assertions/satisfyApiSpec.ts
+++ b/packages/chai-openapi-response-validator/lib/assertions/satisfyApiSpec.ts
@@ -1,10 +1,18 @@
 import {
+  ActualResponse,
   ErrorCode,
   makeResponse,
+  OpenApi2Spec,
+  OpenApi3Spec,
+  OpenApiSpec,
+  ValidationError,
 } from 'openapi-validator';
-import { stringify, joinWithNewLines } from '../utils';
+import { joinWithNewLines, stringify } from '../utils';
 
-export default function (chai, openApiSpec) {
+export default function (
+  chai: Chai.ChaiStatic,
+  openApiSpec: OpenApiSpec,
+): void {
   const { Assertion } = chai;
 
   Assertion.addProperty('satisfyApiSpec', function () {
@@ -23,15 +31,16 @@ export default function (chai, openApiSpec) {
         openApiSpec,
         validationError,
       ),
+      null,
     );
   });
 }
 
 function getExpectedResToSatisfyApiSpecMsg(
-  actualResponse,
-  openApiSpec,
-  validationError,
-) {
+  actualResponse: ActualResponse,
+  openApiSpec: OpenApiSpec,
+  validationError: ValidationError,
+): string | null {
   if (!validationError) {
     return null;
   }
@@ -139,10 +148,10 @@ function getExpectedResToSatisfyApiSpecMsg(
 }
 
 function getExpectedResNotToSatisfyApiSpecMsg(
-  actualResponse,
-  openApiSpec,
+  actualResponse: ActualResponse,
+  openApiSpec: OpenApiSpec,
   validationError,
-) {
+): string | null {
   if (validationError) {
     return null;
   }

--- a/packages/chai-openapi-response-validator/lib/assertions/satisfyApiSpec.ts
+++ b/packages/chai-openapi-response-validator/lib/assertions/satisfyApiSpec.ts
@@ -1,5 +1,7 @@
-import { makeResponse } from 'openapi-validator';
-
+import {
+  ErrorCode,
+  makeResponse,
+} from 'openapi-validator';
 import { stringify, joinWithNewLines } from '../utils';
 
 export default function (chai, openApiSpec) {
@@ -39,24 +41,28 @@ function getExpectedResToSatisfyApiSpecMsg(
   const { method, path: requestPath } = req;
   const unmatchedEndpoint = `${method} ${requestPath}`;
 
-  if (validationError.code === `SERVER_NOT_FOUND`) {
+  if (validationError.code === ErrorCode.ServerNotFound) {
     return joinWithNewLines(
       hint,
       `expected res to satisfy a '${status}' response defined for endpoint '${unmatchedEndpoint}' in your API spec`,
       `res had request path '${requestPath}', but your API spec has no matching servers`,
-      `Servers found in API spec: ${openApiSpec.getServerUrls().join(', ')}`,
+      `Servers found in API spec: ${(openApiSpec as OpenApi3Spec)
+        .getServerUrls()
+        .join(', ')}`,
     );
   }
 
-  if (validationError.code === `BASE_PATH_NOT_FOUND`) {
+  if (validationError.code === ErrorCode.BasePathNotFound) {
     return joinWithNewLines(
       hint,
       `expected res to satisfy a '${status}' response defined for endpoint '${unmatchedEndpoint}' in your API spec`,
-      `res had request path '${requestPath}', but your API spec has basePath '${openApiSpec.spec.basePath}'`,
+      `res had request path '${requestPath}', but your API spec has basePath '${
+        (openApiSpec as OpenApi2Spec).spec.basePath
+      }'`,
     );
   }
 
-  if (validationError.code === `PATH_NOT_FOUND`) {
+  if (validationError.code === ErrorCode.PathNotFound) {
     const pathNotFoundErrorMessage = joinWithNewLines(
       hint,
       `expected res to satisfy a '${status}' response defined for endpoint '${unmatchedEndpoint}' in your API spec`,
@@ -64,14 +70,20 @@ function getExpectedResToSatisfyApiSpecMsg(
       `Paths found in API spec: ${openApiSpec.paths().join(', ')}`,
     );
 
-    if (openApiSpec.didUserDefineBasePath) {
+    if (
+      'didUserDefineBasePath' in openApiSpec &&
+      openApiSpec.didUserDefineBasePath
+    ) {
       return joinWithNewLines(
         pathNotFoundErrorMessage,
         `'${requestPath}' matches basePath \`${openApiSpec.spec.basePath}\` but no <basePath/endpointPath> combinations`,
       );
     }
 
-    if (openApiSpec.didUserDefineServers) {
+    if (
+      'didUserDefineServers' in openApiSpec &&
+      openApiSpec.didUserDefineServers
+    ) {
       return joinWithNewLines(
         pathNotFoundErrorMessage,
         `'${requestPath}' matches servers ${stringify(
@@ -85,7 +97,7 @@ function getExpectedResToSatisfyApiSpecMsg(
   const path = openApiSpec.findOpenApiPathMatchingRequest(req);
   const endpoint = `${method} ${path}`;
 
-  if (validationError.code === 'METHOD_NOT_FOUND') {
+  if (validationError.code === ErrorCode.MethodNotFound) {
     const expectedPathItem = openApiSpec.findExpectedPathItem(req);
     const expectedRequestOperations = Object.keys(expectedPathItem)
       .map((operation) => operation.toUpperCase())
@@ -98,7 +110,7 @@ function getExpectedResToSatisfyApiSpecMsg(
     );
   }
 
-  if (validationError.code === 'STATUS_NOT_FOUND') {
+  if (validationError.code === ErrorCode.StatusNotFound) {
     const expectedResponseOperation = openApiSpec.findExpectedResponseOperation(
       req,
     );
@@ -113,7 +125,7 @@ function getExpectedResToSatisfyApiSpecMsg(
     );
   }
 
-  // validationError.code === 'INVALID_BODY'
+  // validationError.code === ErrorCode.InvalidBody
   const responseDefinition = openApiSpec.findExpectedResponse(actualResponse);
   return joinWithNewLines(
     hint,

--- a/packages/chai-openapi-response-validator/lib/assertions/satisfySchemaInApiSpec.ts
+++ b/packages/chai-openapi-response-validator/lib/assertions/satisfySchemaInApiSpec.ts
@@ -1,6 +1,10 @@
+import type { OpenApiSpec, Schema, ValidationError } from 'openapi-validator';
 import { stringify, joinWithNewLines } from '../utils';
 
-export default function (chai, openApiSpec) {
+export default function (
+  chai: Chai.ChaiStatic,
+  openApiSpec: OpenApiSpec,
+): void {
   const { Assertion, AssertionError } = chai;
 
   Assertion.addMethod('satisfySchemaInApiSpec', function (schemaName) {
@@ -9,6 +13,7 @@ export default function (chai, openApiSpec) {
     const schema = openApiSpec.getSchemaObject(schemaName);
     if (!schema) {
       // alert users they are misusing this assertion
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
       throw new AssertionError(
         'The argument to satisfySchemaInApiSpec must match a schema in your API spec',
       );
@@ -29,32 +34,33 @@ export default function (chai, openApiSpec) {
         schemaName,
         schema,
       ),
+      null,
     );
   });
 }
 
 function getExpectReceivedToSatisfySchemaInApiSpecMsg(
-  actualObject,
-  schemaName,
-  schema,
-  validationError,
+  received: unknown,
+  schemaName: string,
+  schema: Schema,
+  validationError: ValidationError,
 ) {
   return joinWithNewLines(
     `expected object to satisfy the '${schemaName}' schema defined in your API spec`,
     `object did not satisfy it because: ${validationError}`,
-    `object was: ${stringify(actualObject)}`,
+    `object was: ${stringify(received)}`,
     `The '${schemaName}' schema in API spec: ${stringify(schema)}`,
   );
 }
 
 function getExpectReceivedNotToSatisfySchemaInApiSpecMsg(
-  actualObject,
-  schemaName,
-  schema,
+  received: unknown,
+  schemaName: string,
+  schema: Schema,
 ) {
   return joinWithNewLines(
     `expected object not to satisfy the '${schemaName}' schema defined in your API spec`,
-    `object was: ${stringify(actualObject)}`,
+    `object was: ${stringify(received)}`,
     `The '${schemaName}' schema in API spec: ${stringify(schema)}`,
   );
 }

--- a/packages/chai-openapi-response-validator/lib/index.ts
+++ b/packages/chai-openapi-response-validator/lib/index.ts
@@ -1,9 +1,9 @@
-import { makeApiSpec } from 'openapi-validator';
-
+import { makeApiSpec, OpenAPISpecObject } from 'openapi-validator';
 import satisfyApiSpec from './assertions/satisfyApiSpec';
 import satisfySchemaInApiSpec from './assertions/satisfySchemaInApiSpec';
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Chai {
     interface Assertion {
       /**
@@ -20,7 +20,9 @@ declare global {
   }
 }
 
-export default function (filepathOrObject: string | object): Chai.ChaiPlugin {
+export default function (
+  filepathOrObject: string | OpenAPISpecObject,
+): Chai.ChaiPlugin {
   const openApiSpec = makeApiSpec(filepathOrObject);
   return function (chai) {
     satisfyApiSpec(chai, openApiSpec);

--- a/packages/chai-openapi-response-validator/lib/utils.ts
+++ b/packages/chai-openapi-response-validator/lib/utils.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
 
-export const stringify = (obj) =>
+export const stringify = (obj: unknown): string =>
   inspect(obj, { showHidden: false, depth: null });
 
-export const joinWithNewLines = (...lines) => lines.join('\n\n');
+export const joinWithNewLines = (...lines: string[]): string =>
+  lines.join('\n\n');

--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/satisfyApiSpec.test.ts
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/satisfyApiSpec.test.ts
@@ -33,7 +33,7 @@ openApiSpecs.forEach((spec) => {
     describe("when 'res' is not a valid HTTP response object", () => {
       const res = {
         status: 204,
-        body: "should have a 'path' property",
+        body: "must have a 'path' property",
       };
 
       it('fails', () => {
@@ -496,7 +496,7 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).to.throw(
               joinWithNewLines(
                 "expected res to satisfy the '200' response defined for endpoint 'GET /responseBody/object/withMultipleProperties' in your API spec",
-                'res did not satisfy it because: property1 should be string, property2 should be string',
+                'res did not satisfy it because: property1 must be string, property2 must be string',
                 `res contained: ${str({
                   body: { property1: 123, property2: 123 },
                 })}`,

--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/serversDefinedDifferently.test.ts
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/serversDefinedDifferently.test.ts
@@ -57,10 +57,12 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       it('fails', () => {
         const assertion = () => expect(res).to.satisfyApiSpec;
         expect(assertion).to.throw(
-          joinWithNewLines(
-            "expected res to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec",
-            "res had request path '/nonExistentEndpointPath', but your API spec has no matching path",
-            'Paths found in API spec:',
+          new RegExp(
+            `${joinWithNewLines(
+              "expected res to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec",
+              "res had request path '/nonExistentEndpointPath', but your API spec has no matching path",
+              'Paths found in API spec: /endpointPath',
+            )}$`,
           ),
         );
       });
@@ -149,11 +151,13 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       it('fails', () => {
         const assertion = () => expect(res).to.satisfyApiSpec;
         expect(assertion).to.throw(
-          joinWithNewLines(
-            expectedResToSatisfyApiSpec,
-            "expected res to satisfy a '200' response defined for endpoint 'GET /nonExistentServer' in your API spec",
-            "res had request path '/nonExistentServer', but your API spec has no matching servers",
-            'Servers found in API spec: /relativeServer, /differentRelativeServer, /relativeServer2, http://api.example.com/basePath1, https://api.example.com/basePath2, ws://api.example.com/basePath3, wss://api.example.com/basePath4, http://api.example.com:8443/basePath5, http://localhost:3025/basePath6, http://10.0.81.36/basePath7',
+          new RegExp(
+            `${joinWithNewLines(
+              expectedResToSatisfyApiSpec,
+              "expected res to satisfy a '200' response defined for endpoint 'GET /nonExistentServer' in your API spec",
+              "res had request path '/nonExistentServer', but your API spec has no matching servers",
+              'Servers found in API spec: /relativeServer, /differentRelativeServer, /relativeServer2, http://api.example.com/basePath1, https://api.example.com/basePath2, ws://api.example.com/basePath3, wss://api.example.com/basePath4, http://api.example.com:8443/basePath5, http://localhost:3025/basePath6, http://10.0.81.36/basePath7',
+            )}$`,
           ),
         );
       });

--- a/packages/chai-openapi-response-validator/test/assertions/satisfySchemaInApiSpec/satisfySchemaInApiSpec.test.ts
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfySchemaInApiSpec/satisfySchemaInApiSpec.test.ts
@@ -67,7 +67,7 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).to.throw(
               joinWithNewLines(
                 `expected object to satisfy the '${schemaName}' schema defined in your API spec`,
-                'object did not satisfy it because: object should be string',
+                'object did not satisfy it because: object must be string',
                 'object was: 123',
                 `The '${schemaName}' schema in API spec: ${str(
                   expectedSchema,
@@ -108,15 +108,15 @@ openApiSpecs.forEach((spec) => {
         });
 
         describe("'obj' does not satisfy the spec", () => {
-          const invalidObj = 'should be integer';
+          const invalidObj = 'must be integer';
 
           it('fails and outputs a useful error message', () => {
             const assertion = () =>
               expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
             expect(assertion).to.throw(
               joinWithNewLines(
-                'object did not satisfy it because: object should be integer',
-                "object was: 'should be integer'",
+                'object did not satisfy it because: object must be integer',
+                "object was: 'must be integer'",
                 `The '${schemaName}' schema in API spec: ${str(
                   expectedSchema,
                 )}`,
@@ -168,7 +168,7 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).to.throw(
               AssertionError,
               joinWithNewLines(
-                `object did not satisfy it because: property1 should be string`,
+                `object did not satisfy it because: property1 must be string`,
                 `object was: ${str(invalidObj)}`,
                 `The '${schemaName}' schema in API spec: ${str(
                   expectedSchema,
@@ -224,7 +224,7 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
             expect(assertion).to.throw(
               joinWithNewLines(
-                `object did not satisfy it because: property1 should be string`,
+                `object did not satisfy it because: property1 must be string`,
                 `object was: ${str(invalidObj)}`,
                 `The '${schemaName}' schema in API spec: ${str(
                   expectedSchema,
@@ -267,7 +267,7 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
             expect(assertion).to.throw(
               AssertionError,
-              'object did not satisfy it because: property2 should be string',
+              'object did not satisfy it because: property2 must be string',
             );
           });
 
@@ -306,7 +306,7 @@ openApiSpecs.forEach((spec) => {
                 expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
               expect(assertion).to.throw(
                 AssertionError,
-                'object did not satisfy it because: property1 should be string, property2 should be string, object should match some schema in anyOf',
+                'object did not satisfy it because: property1 must be string, property2 must be string, object must match a schema in anyOf',
               );
             });
 
@@ -344,7 +344,7 @@ openApiSpecs.forEach((spec) => {
                 expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
               expect(assertion).to.throw(
                 AssertionError,
-                'object did not satisfy it because: object should match exactly one schema in oneOf',
+                'object did not satisfy it because: object must match exactly one schema in oneOf',
               );
             });
 

--- a/packages/chai-openapi-response-validator/test/setup.test.ts
+++ b/packages/chai-openapi-response-validator/test/setup.test.ts
@@ -6,20 +6,20 @@ import chaiResponseValidator from '..';
 
 const { expect } = chai;
 const invalidArgErrorMessage =
-  'The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.';
+  'The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.\nError details: ';
 
-describe('chaiResponseValidator(stringOrObject)', () => {
+describe('chaiResponseValidator(filepathOrObject)', () => {
   describe('number', () => {
     it('throws an error', () => {
       const func = () => chaiResponseValidator(123 as never);
-      expect(func).to.throw(invalidArgErrorMessage);
+      expect(func).to.throw(`${invalidArgErrorMessage}Received type 'number'`);
     });
   });
 
   describe('array', () => {
     it('throws an error', () => {
       const func = () => chaiResponseValidator([] as never);
-      expect(func).to.throw(invalidArgErrorMessage);
+      expect(func).to.throw(`${invalidArgErrorMessage}Received type 'array'`);
     });
   });
 
@@ -51,7 +51,7 @@ describe('chaiResponseValidator(stringOrObject)', () => {
     it('throws an error', () => {
       const func = () => chaiResponseValidator('./');
       expect(func).to.throw(
-        `${invalidArgErrorMessage}\nError: './' is not an absolute filepath`,
+        `${invalidArgErrorMessage}'./' is not an absolute filepath`,
       );
     });
   });
@@ -60,7 +60,7 @@ describe('chaiResponseValidator(stringOrObject)', () => {
     it('throws an error', () => {
       const func = () => chaiResponseValidator('/non-existent-file.yml');
       expect(func).to.throw(
-        `${invalidArgErrorMessage}\nError: ENOENT: no such file or directory, open '/non-existent-file.yml'`,
+        `${invalidArgErrorMessage}ENOENT: no such file or directory, open '/non-existent-file.yml'`,
       );
     });
   });
@@ -71,9 +71,7 @@ describe('chaiResponseValidator(stringOrObject)', () => {
         '../../commonTestResources/exampleOpenApiFiles/invalid/fileFormat/neitherYamlNorJson.js',
       );
       const func = () => chaiResponseValidator(pathToApiSpec);
-      expect(func).to.throw(
-        `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\n`,
-      );
+      expect(func).to.throw(`${invalidArgErrorMessage}Invalid YAML or JSON:\n`);
     });
   });
 
@@ -96,7 +94,7 @@ describe('chaiResponseValidator(stringOrObject)', () => {
         );
         const func = () => chaiResponseValidator(pathToApiSpec);
         expect(func).to.throw(
-          `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\nduplicated mapping key`,
+          `${invalidArgErrorMessage}Invalid YAML or JSON:\nduplicated mapping key`,
         );
       });
     });
@@ -107,7 +105,7 @@ describe('chaiResponseValidator(stringOrObject)', () => {
         );
         const func = () => chaiResponseValidator(pathToApiSpec);
         expect(func).to.throw(
-          `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\nduplicated mapping key`,
+          `${invalidArgErrorMessage}Invalid YAML or JSON:\nduplicated mapping key`,
         );
       });
     });

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/basePathDefinedDifferently.test.ts
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/basePathDefinedDifferently.test.ts
@@ -2,10 +2,22 @@ import path from 'path';
 import {
   RECEIVED_COLOR as red,
   EXPECTED_COLOR as green,
+  matcherHint,
 } from 'jest-matcher-utils';
 
 import { joinWithNewLines } from '../../../../../commonTestResources/utils';
 import jestOpenAPI from '../../..';
+
+const expectReceivedToSatisfyApiSpec = matcherHint(
+  'toSatisfyApiSpec',
+  undefined,
+  '',
+  {
+    comment:
+      "Matches 'received' to a response defined in your API spec, then validates 'received' against it",
+    isNot: false,
+  },
+);
 
 const startOfAssertionErrorMessage = 'expect';
 
@@ -56,11 +68,14 @@ describe('Using OpenAPI 2 specs that define basePath differently', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
           // prettier-ignore
-          `${joinWithNewLines(
-            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`,
-            `${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`,
-            `Paths found in API spec: ${green('/endpointPath')}`,
-          )}`,
+          new Error(
+            joinWithNewLines(
+              expectReceivedToSatisfyApiSpec,
+              `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`,
+              `${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`,
+              `Paths found in API spec: ${green('/endpointPath')}`,
+            ),
+          ),
         );
       });
 

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/serversDefinedDifferently.test.ts
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/serversDefinedDifferently.test.ts
@@ -72,10 +72,13 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
           // prettier-ignore
-          joinWithNewLines(
-            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`,
-            `${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`,
-            'Paths found in API spec:',
+          new Error(
+            joinWithNewLines(
+              expectReceivedToSatisfyApiSpec,
+              `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`,
+              `${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`,
+              `Paths found in API spec: ${green('/endpointPath')}`,
+            ),
           ),
         );
       });
@@ -167,7 +170,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         expect(assertion).toThrow(
           // prettier-ignore
           joinWithNewLines(
-            `${expectReceivedToSatisfyApiSpec}`,
+            expectReceivedToSatisfyApiSpec,
             `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentServer' in your API spec`,
             `${red('received')} had request path ${red('/nonExistentServer')}, but your API spec has no matching servers`,
             `Servers found in API spec: ${green('/relativeServer, /differentRelativeServer, /relativeServer2, http://api.example.com/basePath1, https://api.example.com/basePath2, ws://api.example.com/basePath3, wss://api.example.com/basePath4, http://api.example.com:8443/basePath5, http://localhost:3025/basePath6, http://10.0.81.36/basePath7')}`,

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/toSatisfyApiSpec.test.ts
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/toSatisfyApiSpec.test.ts
@@ -540,7 +540,7 @@ openApiSpecs.forEach((spec) => {
                 joinWithNewLines(
                   expectReceivedToSatisfyApiSpec,
                   `expected ${red('received')} to satisfy the '200' response defined for endpoint 'GET /responseBody/object/withMultipleProperties' in your API spec`,
-                  `${red('received')} did not satisfy it because: property1 should be string, property2 should be string`,
+                  `${red('received')} did not satisfy it because: property1 must be string, property2 must be string`,
                   `${red('received')} contained: ${red(str({ body: { property1: 123, property2: 123 } }))}`,
                   `The '200' response defined for endpoint 'GET /responseBody/object/withMultipleProperties' in API spec: ${green(str(responseDefinition))}`,
                 ),

--- a/packages/jest-openapi/__test__/matchers/toSatisfySchemaInApiSpec/toSatisfySchemaInApiSpec.test.ts
+++ b/packages/jest-openapi/__test__/matchers/toSatisfySchemaInApiSpec/toSatisfySchemaInApiSpec.test.ts
@@ -99,7 +99,7 @@ openApiSpecs.forEach((spec) => {
                 joinWithNewLines(
                   expectReceivedToSatisfySchemaInApiSpec,
                   `expected ${red('received')} to satisfy the '${schemaName}' schema defined in your API spec`,
-                  `${red('received')} did not satisfy it because: object should be string`,
+                  `${red('received')} did not satisfy it because: object must be string`,
                   `${red('received')} was: ${red(123)}`,
                   `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
                 ),
@@ -138,7 +138,7 @@ openApiSpecs.forEach((spec) => {
         });
 
         describe("'obj' does not satisfy the spec", () => {
-          const invalidObj = 'should be integer';
+          const invalidObj = 'must be integer';
 
           it('fails and outputs a useful error message', () => {
             const assertion = () =>
@@ -146,8 +146,8 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).toThrow(
               // prettier-ignore
               joinWithNewLines(
-                `${red('received')} did not satisfy it because: object should be integer`,
-                `${red('received')} was: ${red('\'should be integer\'')}`,
+                `${red('received')} did not satisfy it because: object must be integer`,
+                `${red('received')} was: ${red('\'must be integer\'')}`,
                 `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
               ),
             );
@@ -196,7 +196,7 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).toThrow(
               // prettier-ignore
               joinWithNewLines(
-                `${red('received')} did not satisfy it because: property1 should be string`,
+                `${red('received')} did not satisfy it because: property1 must be string`,
                 `${red('received')} was: ${red(str(invalidObj))}`,
                 `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
               ),
@@ -249,7 +249,7 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).toThrow(
               // prettier-ignore
               joinWithNewLines(
-                `${red('received')} did not satisfy it because: property1 should be string`,
+                `${red('received')} did not satisfy it because: property1 must be string`,
                 `${red('received')} was: ${red(str(invalidObj))}`,
                 `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
               ),
@@ -289,7 +289,7 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              `${red('received')} did not satisfy it because: property2 should be string`,
+              `${red('received')} did not satisfy it because: property2 must be string`,
             );
           });
 
@@ -327,7 +327,7 @@ openApiSpecs.forEach((spec) => {
                 expect(invalidObj).toSatisfySchemaInApiSpec(schemaName);
               expect(assertion).toThrow(
                 // prettier-ignore
-                `${red('received')} did not satisfy it because: property1 should be string, property2 should be string, object should match some schema in anyOf`,
+                `${red('received')} did not satisfy it because: property1 must be string, property2 must be string, object must match a schema in anyOf`,
               );
             });
 
@@ -364,7 +364,7 @@ openApiSpecs.forEach((spec) => {
                 expect(invalidObj).toSatisfySchemaInApiSpec(schemaName);
               expect(assertion).toThrow(
                 // prettier-ignore
-                `${red('received')} did not satisfy it because: object should match exactly one schema in oneOf`,
+                `${red('received')} did not satisfy it because: object must match exactly one schema in oneOf`,
               );
             });
 

--- a/packages/jest-openapi/__test__/setup.test.ts
+++ b/packages/jest-openapi/__test__/setup.test.ts
@@ -4,20 +4,20 @@ import fs from 'fs-extra';
 import jestOpenAPI from '..';
 
 const invalidArgErrorMessage =
-  'The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.';
+  'The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.\nError details: ';
 
-describe('jestOpenAPI(stringOrObject)', () => {
+describe('jestOpenAPI(filepathOrObject)', () => {
   describe('number', () => {
     it('throws an error', () => {
       const func = () => jestOpenAPI(123 as never);
-      expect(func).toThrow(new Error(invalidArgErrorMessage));
+      expect(func).toThrow(`${invalidArgErrorMessage}Received type 'number'`);
     });
   });
 
   describe('array', () => {
     it('throws an error', () => {
       const func = () => jestOpenAPI([] as never);
-      expect(func).toThrow(new Error(invalidArgErrorMessage));
+      expect(func).toThrow(`${invalidArgErrorMessage}Received type 'array'`);
     });
   });
 
@@ -49,7 +49,7 @@ describe('jestOpenAPI(stringOrObject)', () => {
     it('throws an error', () => {
       const func = () => jestOpenAPI('./');
       expect(func).toThrow(
-        `${invalidArgErrorMessage}\nError: './' is not an absolute filepath`,
+        `${invalidArgErrorMessage}'./' is not an absolute filepath`,
       );
     });
   });
@@ -58,7 +58,7 @@ describe('jestOpenAPI(stringOrObject)', () => {
     it('throws an error', () => {
       const func = () => jestOpenAPI('/non-existent-file.yml');
       expect(func).toThrow(
-        `${invalidArgErrorMessage}\nError: ENOENT: no such file or directory, open '/non-existent-file.yml'`,
+        `${invalidArgErrorMessage}ENOENT: no such file or directory, open '/non-existent-file.yml'`,
       );
     });
   });
@@ -69,9 +69,7 @@ describe('jestOpenAPI(stringOrObject)', () => {
         '../../commonTestResources/exampleOpenApiFiles/invalid/fileFormat/neitherYamlNorJson.js',
       );
       const func = () => jestOpenAPI(pathToApiSpec);
-      expect(func).toThrow(
-        `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\n`,
-      );
+      expect(func).toThrow(`${invalidArgErrorMessage}Invalid YAML or JSON:\n`);
     });
   });
 
@@ -94,7 +92,7 @@ describe('jestOpenAPI(stringOrObject)', () => {
         );
         const func = () => jestOpenAPI(pathToApiSpec);
         expect(func).toThrow(
-          `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\nduplicated mapping key`,
+          `${invalidArgErrorMessage}Invalid YAML or JSON:\nduplicated mapping key`,
         );
       });
     });
@@ -105,7 +103,7 @@ describe('jestOpenAPI(stringOrObject)', () => {
         );
         const func = () => jestOpenAPI(pathToApiSpec);
         expect(func).toThrow(
-          `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\nduplicated mapping key`,
+          `${invalidArgErrorMessage}Invalid YAML or JSON:\nduplicated mapping key`,
         );
       });
     });

--- a/packages/jest-openapi/__test__/setup.test.ts
+++ b/packages/jest-openapi/__test__/setup.test.ts
@@ -3,56 +3,81 @@ import fs from 'fs-extra';
 
 import jestOpenAPI from '..';
 
-const genericArgTypeErrMsg =
-  'The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.\nError details: ';
+const invalidArgErrorMessage =
+  'The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.';
 
-describe('jestOpenAPI(pathToApiSpec)', () => {
-  describe('neither string nor object', () => {
-    describe('number', () => {
-      it('throws a relevant error', () => {
-        const func = () => jestOpenAPI(123 as any);
-        expect(func).toThrow(`${genericArgTypeErrMsg}Received type 'number'`);
-      });
+describe('jestOpenAPI(stringOrObject)', () => {
+  describe('number', () => {
+    it('throws an error', () => {
+      const func = () => jestOpenAPI(123 as never);
+      expect(func).toThrow(new Error(invalidArgErrorMessage));
     });
-    describe('array', () => {
-      it('throws a relevant error', () => {
-        const func = () => jestOpenAPI([]);
-        expect(func).toThrow(`${genericArgTypeErrMsg}Received type 'array'`);
-      });
+  });
+
+  describe('array', () => {
+    it('throws an error', () => {
+      const func = () => jestOpenAPI([] as never);
+      expect(func).toThrow(new Error(invalidArgErrorMessage));
+    });
+  });
+
+  describe('object that is not an OpenAPI spec', () => {
+    it('throws an error', () => {
+      const func = () => jestOpenAPI({} as never);
+      expect(func).toThrow('Invalid OpenAPI spec: [');
+    });
+  });
+
+  describe('object that is an incomplete OpenAPI spec', () => {
+    it('throws an error', () => {
+      const func = () => jestOpenAPI({ openapi: '3.0.0' } as never);
+      expect(func).toThrow('Invalid OpenAPI spec: [');
+    });
+  });
+
+  describe('object representing a valid OpenAPI spec', () => {
+    it("successfully extends jest's `expect`", () => {
+      const pathToApiSpec = path.resolve(
+        '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.json',
+      );
+      const apiSpec = fs.readJSONSync(pathToApiSpec);
+      expect(() => jestOpenAPI(apiSpec)).not.toThrow();
     });
   });
 
   describe('non-absolute path', () => {
-    it('throws a relevant error', () => {
+    it('throws an error', () => {
       const func = () => jestOpenAPI('./');
       expect(func).toThrow(
-        `${genericArgTypeErrMsg}'./' is not an absolute filepath`,
+        `${invalidArgErrorMessage}\nError: './' is not an absolute filepath`,
       );
     });
   });
 
   describe('absolute path to a non-existent file', () => {
-    it('throws a relevant error', () => {
+    it('throws an error', () => {
       const func = () => jestOpenAPI('/non-existent-file.yml');
       expect(func).toThrow(
-        `${genericArgTypeErrMsg}ENOENT: no such file or directory, open '/non-existent-file.yml'`,
+        `${invalidArgErrorMessage}\nError: ENOENT: no such file or directory, open '/non-existent-file.yml'`,
       );
     });
   });
 
   describe('absolute path to a file that is neither YAML nor JSON', () => {
-    it('throws a relevant error', () => {
+    it('throws an error', () => {
       const pathToApiSpec = path.resolve(
         '../../commonTestResources/exampleOpenApiFiles/invalid/fileFormat/neitherYamlNorJson.js',
       );
       const func = () => jestOpenAPI(pathToApiSpec);
-      expect(func).toThrow(`${genericArgTypeErrMsg}Invalid YAML or JSON:\n`);
+      expect(func).toThrow(
+        `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\n`,
+      );
     });
   });
 
   describe('absolute path to an invalid OpenAPI file', () => {
     describe('YAML file that is empty', () => {
-      it('throws a relevant error', () => {
+      it('throws an error', () => {
         const pathToApiSpec = path.resolve(
           '../../commonTestResources/exampleOpenApiFiles/invalid/fileFormat/emptyYaml.yml',
         );
@@ -63,29 +88,29 @@ describe('jestOpenAPI(pathToApiSpec)', () => {
       });
     });
     describe('YAML file that is invalid YAML', () => {
-      it('throws a relevant error', () => {
+      it('throws an error', () => {
         const pathToApiSpec = path.resolve(
           '../../commonTestResources/exampleOpenApiFiles/invalid/fileFormat/invalidYamlFormat.yml',
         );
         const func = () => jestOpenAPI(pathToApiSpec);
         expect(func).toThrow(
-          `${genericArgTypeErrMsg}Invalid YAML or JSON:\nduplicated mapping key`,
+          `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\nduplicated mapping key`,
         );
       });
     });
     describe('JSON file that is invalid JSON', () => {
-      it('throws a relevant error', () => {
+      it('throws an error', () => {
         const pathToApiSpec = path.resolve(
           '../../commonTestResources/exampleOpenApiFiles/invalid/fileFormat/invalidJsonFormat.json',
         );
         const func = () => jestOpenAPI(pathToApiSpec);
         expect(func).toThrow(
-          `${genericArgTypeErrMsg}Invalid YAML or JSON:\nduplicated mapping key`,
+          `${invalidArgErrorMessage}\nError: Invalid YAML or JSON:\nduplicated mapping key`,
         );
       });
     });
     describe('YAML file that is invalid OpenAPI 3', () => {
-      it('throws a relevant error', () => {
+      it('throws an error', () => {
         const pathToApiSpec = path.resolve(
           '../../commonTestResources/exampleOpenApiFiles/invalid/openApi/openApi3.yml',
         );
@@ -94,7 +119,7 @@ describe('jestOpenAPI(pathToApiSpec)', () => {
       });
     });
     describe('JSON file that is invalid OpenAPI 2', () => {
-      it('throws a relevant error', () => {
+      it('throws an error', () => {
         const pathToApiSpec = path.resolve(
           '../../commonTestResources/exampleOpenApiFiles/invalid/openApi/openApi2.json',
         );
@@ -104,38 +129,21 @@ describe('jestOpenAPI(pathToApiSpec)', () => {
     });
   });
 
-  describe('absolute path to a valid OpenAPI file', () => {
-    describe('YAML', () => {
-      it("successfully extends jest's `expect`", () => {
-        const pathToApiSpec = path.resolve(
-          '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.yml',
-        );
-        expect(() => jestOpenAPI(pathToApiSpec)).not.toThrow();
-      });
-    });
-    describe('JSON', () => {
-      it("successfully extends jest's `expect`", () => {
-        const pathToApiSpec = path.resolve(
-          '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.json',
-        );
-        expect(() => jestOpenAPI(pathToApiSpec)).not.toThrow();
-      });
+  describe('absolute path to a valid OpenAPI YAML file', () => {
+    it("successfully extends jest's `expect`", () => {
+      const pathToApiSpec = path.resolve(
+        '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.yml',
+      );
+      expect(() => jestOpenAPI(pathToApiSpec)).not.toThrow();
     });
   });
 
-  describe('object representing a valid OpenAPI file', () => {
+  describe('absolute path to a valid OpenAPI JSON file', () => {
     it("successfully extends jest's `expect`", () => {
       const pathToApiSpec = path.resolve(
         '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.json',
       );
-      const apiSpec = fs.readJSONSync(pathToApiSpec);
-      expect(() => jestOpenAPI(apiSpec)).not.toThrow();
-    });
-  });
-  describe('object not representing a valid OpenAPI file', () => {
-    it('throws a relevant error', () => {
-      const func = () => jestOpenAPI({ foo: 'foo' });
-      expect(func).toThrow('Invalid OpenAPI spec: [');
+      expect(() => jestOpenAPI(pathToApiSpec)).not.toThrow();
     });
   });
 });

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -40,7 +40,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^27.0.1",
     "axios": "^0.21.1",
     "eslint": "^7.11.0",
     "eslint-config-airbnb-base": "^14.2.0",

--- a/packages/jest-openapi/src/index.ts
+++ b/packages/jest-openapi/src/index.ts
@@ -1,8 +1,9 @@
-import { makeApiSpec } from 'openapi-validator';
+import { makeApiSpec, OpenAPISpecObject } from 'openapi-validator';
 import toSatisfyApiSpec from './matchers/toSatisfyApiSpec';
 import toSatisfySchemaInApiSpec from './matchers/toSatisfySchemaInApiSpec';
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
     interface Matchers<R> {
       /**
@@ -19,14 +20,14 @@ declare global {
   }
 }
 
-export default function (filepathOrObject: string | object): void {
+export default function (filepathOrObject: string | OpenAPISpecObject): void {
   const openApiSpec = makeApiSpec(filepathOrObject);
 
   const jestMatchers = {
     toSatisfyApiSpec(received) {
       return toSatisfyApiSpec.call(this, received, openApiSpec);
     },
-    toSatisfySchemaInApiSpec(received, schemaName) {
+    toSatisfySchemaInApiSpec(received, schemaName: string) {
       return toSatisfySchemaInApiSpec.call(
         this,
         received,
@@ -36,7 +37,7 @@ export default function (filepathOrObject: string | object): void {
     },
   };
 
-  const jestExpect = (global as any).expect;
+  const jestExpect = (global as { expect?: jest.Expect }).expect;
 
   /* istanbul ignore next */
   if (jestExpect !== undefined) {

--- a/packages/jest-openapi/src/matchers/toSatisfyApiSpec.ts
+++ b/packages/jest-openapi/src/matchers/toSatisfyApiSpec.ts
@@ -1,21 +1,31 @@
 import {
-  matcherHint,
-  RECEIVED_COLOR,
   EXPECTED_COLOR,
+  matcherHint,
+  MatcherHintOptions,
+  RECEIVED_COLOR,
 } from 'jest-matcher-utils';
 import {
+  ActualResponse,
   ErrorCode,
   makeResponse,
+  OpenApi2Spec,
+  OpenApi3Spec,
+  OpenApiSpec,
+  RawResponse,
+  ValidationError,
 } from 'openapi-validator';
-import { stringify, joinWithNewLines } from '../utils';
+import { joinWithNewLines, stringify } from '../utils';
 
-export default function (received, openApiSpec) {
-  const actualResponse = makeResponse(received);
+export default function (
+  received: unknown,
+  openApiSpec: OpenApiSpec,
+): jest.CustomMatcherResult {
+  const actualResponse = makeResponse(received as RawResponse);
 
   const validationError = openApiSpec.validateResponse(actualResponse);
   const pass = !validationError;
 
-  const matcherHintOptions = {
+  const matcherHintOptions: MatcherHintOptions = {
     comment:
       "Matches 'received' to a response defined in your API spec, then validates 'received' against it",
     isNot: this.isNot,
@@ -49,11 +59,11 @@ export default function (received, openApiSpec) {
 }
 
 function getExpectReceivedToSatisfyApiSpecMsg(
-  actualResponse,
-  openApiSpec,
-  validationError,
-  hint,
-) {
+  actualResponse: ActualResponse,
+  openApiSpec: OpenApiSpec,
+  validationError: ValidationError,
+  hint: string,
+): string {
   const { status, req } = actualResponse;
   const { method, path: requestPath } = req;
   const unmatchedEndpoint = `${method} ${requestPath}`;
@@ -157,10 +167,10 @@ function getExpectReceivedToSatisfyApiSpecMsg(
 }
 
 function getExpectReceivedNotToSatisfyApiSpecMsg(
-  actualResponse,
-  openApiSpec,
-  hint,
-) {
+  actualResponse: ActualResponse,
+  openApiSpec: OpenApiSpec,
+  hint: string,
+): string {
   const { status, req } = actualResponse;
   const responseDefinition = openApiSpec.findExpectedResponse(actualResponse);
   const endpoint = `${req.method} ${openApiSpec.findOpenApiPathMatchingRequest(

--- a/packages/jest-openapi/src/matchers/toSatisfyApiSpec.ts
+++ b/packages/jest-openapi/src/matchers/toSatisfyApiSpec.ts
@@ -3,8 +3,10 @@ import {
   RECEIVED_COLOR,
   EXPECTED_COLOR,
 } from 'jest-matcher-utils';
-import { makeResponse } from 'openapi-validator';
-
+import {
+  ErrorCode,
+  makeResponse,
+} from 'openapi-validator';
 import { stringify, joinWithNewLines } from '../utils';
 
 export default function (received, openApiSpec) {
@@ -56,26 +58,26 @@ function getExpectReceivedToSatisfyApiSpecMsg(
   const { method, path: requestPath } = req;
   const unmatchedEndpoint = `${method} ${requestPath}`;
 
-  if (validationError.code === `SERVER_NOT_FOUND`) {
+  if (validationError.code === ErrorCode.ServerNotFound) {
     // prettier-ignore
     return joinWithNewLines(
       hint,
       `expected ${RECEIVED_COLOR('received')} to satisfy a '${status}' response defined for endpoint '${unmatchedEndpoint}' in your API spec`,
       `${RECEIVED_COLOR('received')} had request path ${RECEIVED_COLOR(requestPath)}, but your API spec has no matching servers`,
-      `Servers found in API spec: ${EXPECTED_COLOR(openApiSpec.getServerUrls().join(', '))}`,
+      `Servers found in API spec: ${EXPECTED_COLOR((openApiSpec as OpenApi3Spec).getServerUrls().join(', '))}`,
     );
   }
 
-  if (validationError.code === `BASE_PATH_NOT_FOUND`) {
+  if (validationError.code === ErrorCode.BasePathNotFound) {
     // prettier-ignore
     return joinWithNewLines(
       hint,
       `expected ${RECEIVED_COLOR('received')} to satisfy a '${status}' response defined for endpoint '${unmatchedEndpoint}' in your API spec`,
-      `${RECEIVED_COLOR('received')} had request path ${RECEIVED_COLOR(requestPath)}, but your API spec has basePath ${EXPECTED_COLOR(openApiSpec.spec.basePath)}`,
+      `${RECEIVED_COLOR('received')} had request path ${RECEIVED_COLOR(requestPath)}, but your API spec has basePath ${EXPECTED_COLOR((openApiSpec as OpenApi2Spec).spec.basePath)}`,
     );
   }
 
-  if (validationError.code === `PATH_NOT_FOUND`) {
+  if (validationError.code === ErrorCode.PathNotFound) {
     // prettier-ignore
     const pathNotFoundErrorMessage = joinWithNewLines(
       hint,
@@ -84,7 +86,10 @@ function getExpectReceivedToSatisfyApiSpecMsg(
       `Paths found in API spec: ${EXPECTED_COLOR(openApiSpec.paths().join(', '))}`,
     );
 
-    if (openApiSpec.didUserDefineBasePath) {
+    if (
+      'didUserDefineBasePath' in openApiSpec &&
+      openApiSpec.didUserDefineBasePath
+    ) {
       // prettier-ignore
       return joinWithNewLines(
         pathNotFoundErrorMessage,
@@ -92,7 +97,10 @@ function getExpectReceivedToSatisfyApiSpecMsg(
       );
     }
 
-    if (openApiSpec.didUserDefineServers) {
+    if (
+      'didUserDefineServers' in openApiSpec &&
+      openApiSpec.didUserDefineServers
+    ) {
       return joinWithNewLines(
         pathNotFoundErrorMessage,
         `'${requestPath}' matches servers ${stringify(
@@ -106,7 +114,7 @@ function getExpectReceivedToSatisfyApiSpecMsg(
   const path = openApiSpec.findOpenApiPathMatchingRequest(req);
   const endpoint = `${method} ${path}`;
 
-  if (validationError.code === 'METHOD_NOT_FOUND') {
+  if (validationError.code === ErrorCode.MethodNotFound) {
     const expectedPathItem = openApiSpec.findExpectedPathItem(req);
     const expectedRequestOperations = Object.keys(expectedPathItem)
       .map((operation) => operation.toUpperCase())
@@ -120,7 +128,7 @@ function getExpectReceivedToSatisfyApiSpecMsg(
     );
   }
 
-  if (validationError.code === 'STATUS_NOT_FOUND') {
+  if (validationError.code === ErrorCode.StatusNotFound) {
     const expectedResponseOperation = openApiSpec.findExpectedResponseOperation(
       req,
     );
@@ -136,7 +144,7 @@ function getExpectReceivedToSatisfyApiSpecMsg(
     );
   }
 
-  // validationError.code === 'INVALID_BODY'
+  // validationError.code === ErrorCode.InvalidBody
   const responseDefinition = openApiSpec.findExpectedResponse(actualResponse);
   // prettier-ignore
   return joinWithNewLines(

--- a/packages/jest-openapi/src/matchers/toSatisfySchemaInApiSpec.ts
+++ b/packages/jest-openapi/src/matchers/toSatisfySchemaInApiSpec.ts
@@ -1,15 +1,19 @@
 import {
-  RECEIVED_COLOR,
   EXPECTED_COLOR,
-  matcherHint,
   matcherErrorMessage,
+  matcherHint,
   printExpected,
   printWithType,
+  RECEIVED_COLOR,
 } from 'jest-matcher-utils';
+import type { OpenApiSpec, Schema, ValidationError } from 'openapi-validator';
+import { joinWithNewLines, stringify } from '../utils';
 
-import { stringify, joinWithNewLines } from '../utils';
-
-export default function (received, schemaName, openApiSpec) {
+export default function (
+  received: unknown,
+  schemaName: string,
+  openApiSpec: OpenApiSpec,
+): jest.CustomMatcherResult {
   const matcherHintOptions = {
     comment:
       "Matches 'received' to a schema defined in your API spec, then validates 'received' against it",
@@ -62,12 +66,12 @@ export default function (received, schemaName, openApiSpec) {
 }
 
 function getExpectReceivedToSatisfySchemaInApiSpecMsg(
-  received,
-  schemaName,
-  schema,
-  validationError,
-  hint,
-) {
+  received: unknown,
+  schemaName: string,
+  schema: Schema,
+  validationError: ValidationError,
+  hint: string,
+): string {
   // prettier-ignore
   return joinWithNewLines(
     hint,
@@ -79,11 +83,11 @@ function getExpectReceivedToSatisfySchemaInApiSpecMsg(
 }
 
 function getExpectReceivedNotToSatisfySchemaInApiSpecMsg(
-  received,
-  schemaName,
-  schema,
-  hint,
-) {
+  received: unknown,
+  schemaName: string,
+  schema: Schema,
+  hint: string,
+): string {
   // prettier-ignore
   return joinWithNewLines(
     hint,

--- a/packages/jest-openapi/src/utils.ts
+++ b/packages/jest-openapi/src/utils.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
 
-export const stringify = (obj) =>
+export const stringify = (obj: unknown): string =>
   inspect(obj, { showHidden: false, depth: null });
 
-export const joinWithNewLines = (...lines) => lines.join('\n\n');
+export const joinWithNewLines = (...lines: string[]): string =>
+  lines.join('\n\n');

--- a/packages/openapi-validator/lib/classes/AbstractOpenApiSpec.ts
+++ b/packages/openapi-validator/lib/classes/AbstractOpenApiSpec.ts
@@ -1,129 +1,152 @@
 import OpenAPIResponseValidator from 'openapi-response-validator';
-
+import type { OpenAPI, OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import { getPathname } from '../utils/common.utils';
-import ValidationError from './errors/ValidationError';
+import type { ActualRequest, ActualResponse } from './AbstractResponse';
+import ValidationError, { ErrorCode } from './errors/ValidationError';
+
+type Document = OpenAPI.Document;
+
+type Operation = OpenAPI.Operation;
+
+type HttpMethods = OpenAPIV2.HttpMethods;
+
+type PathsObject =
+  | OpenAPIV2.PathsObject
+  | OpenAPIV3.PathsObject
+  | OpenAPIV3_1.PathsObject;
+
+type PathItemObject =
+  | OpenAPIV2.PathItemObject
+  | OpenAPIV3.PathItemObject
+  | OpenAPIV3_1.PathItemObject;
+
+export type ResponseObject =
+  | OpenAPIV2.ResponseObject
+  | OpenAPIV3.ResponseObject
+  | OpenAPIV3_1.ResponseObject;
+
+export type Schema = OpenAPIV2.Schema | OpenAPIV3.SchemaObject;
 
 export default abstract class OpenApiSpec {
-  protected spec: any;
+  protected abstract getSchemaObjects(): Record<string, Schema>;
 
-  protected abstract getSchemaObjects(): any;
+  protected abstract findResponseDefinition(
+    referenceString: string,
+  ): ResponseObject;
 
-  protected abstract findResponseDefinition(referenceString: string): any;
+  protected abstract findOpenApiPathMatchingPathname(pathname: string): string;
 
-  protected abstract findOpenApiPathMatchingPathname(pathname: string): any;
+  protected abstract getComponentDefinitionsProperty():
+    | Pick<OpenAPIV2.Document, 'definitions'>
+    | Pick<OpenAPIV3.Document, 'components'>;
 
-  protected abstract getComponentDefinitionsProperty(): any;
+  constructor(protected spec: Document) {}
 
-  constructor(spec) {
-    this.spec = spec;
-  }
-
-  /**
-   * @returns {[PathItemObject]} [PathItemObject]
-   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#path-item-object}
-   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject}
-   */
-  pathsObject() {
+  pathsObject(): PathsObject | undefined {
     return this.spec.paths;
   }
 
-  getPathItem(openApiPath) {
+  getPathItem(openApiPath: string): PathItemObject | undefined {
     return this.pathsObject()[openApiPath];
   }
 
-  paths() {
+  paths(): string[] {
     return Object.keys(this.pathsObject());
   }
 
-  getSchemaObject(schemaName) {
+  getSchemaObject(schemaName: string): Schema {
     const schemaObjects = this.getSchemaObjects();
     return schemaObjects[schemaName];
   }
 
-  /**
-   * @returns {ResponseObject} ResponseObject
-   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#response-object}
-   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject}
-   */
-  findExpectedResponse(actualResponse) {
+  getExpectedResponse(
+    responseOperation: Operation,
+    status: ActualResponse['status'],
+  ): ResponseObject | undefined {
+    const response = responseOperation.responses[status];
+    if (!response) {
+      return undefined;
+    }
+    if ('$ref' in response) {
+      return this.findResponseDefinition(response.$ref);
+    }
+    return response;
+  }
+
+  findExpectedResponse(
+    actualResponse: ActualResponse,
+  ): Record<string, ResponseObject> {
     const actualRequest = actualResponse.req;
     const expectedResponseOperation = this.findExpectedResponseOperation(
       actualRequest,
     );
     if (!expectedResponseOperation) {
-      throw new ValidationError('METHOD_NOT_FOUND');
+      throw new ValidationError(ErrorCode.MethodNotFound);
     }
 
     const { status } = actualResponse;
-    let expectedResponse = expectedResponseOperation.responses[status];
-    if (expectedResponse && expectedResponse.$ref) {
-      expectedResponse = this.findResponseDefinition(expectedResponse.$ref);
-    }
+    const expectedResponse = this.getExpectedResponse(
+      expectedResponseOperation,
+      status,
+    );
     if (!expectedResponse) {
-      throw new ValidationError('STATUS_NOT_FOUND');
+      throw new ValidationError(ErrorCode.StatusNotFound);
     }
 
     return { [status]: expectedResponse };
   }
 
-  findOpenApiPathMatchingRequest(actualRequest) {
+  findOpenApiPathMatchingRequest(actualRequest: ActualRequest): string {
     const actualPathname = getPathname(actualRequest);
     const openApiPath = this.findOpenApiPathMatchingPathname(actualPathname);
     return openApiPath;
   }
 
-  /**
-   * @returns {PathItemObject} PathItemObject
-   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#path-item-object}
-   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject}
-   */
-  findExpectedPathItem(actualRequest) {
+  findExpectedPathItem(actualRequest: ActualRequest): PathItemObject {
     const actualPathname = getPathname(actualRequest);
     const openApiPath = this.findOpenApiPathMatchingPathname(actualPathname);
     const pathItemObject = this.getPathItem(openApiPath);
     return pathItemObject;
   }
 
-  /**
-   * @returns {OperationObject} OperationObject
-   * @see OpenAPI2 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object}
-   * @see OpenAPI3 {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject}
-   */
-  findExpectedResponseOperation(actualRequest) {
+  findExpectedResponseOperation(actualRequest: ActualRequest): Operation {
     const pathItemObject = this.findExpectedPathItem(actualRequest);
-    const operationObject = pathItemObject[actualRequest.method.toLowerCase()];
+    const operationObject =
+      pathItemObject[actualRequest.method.toLowerCase() as HttpMethods];
     return operationObject;
   }
 
-  validateResponse(actualResponse) {
-    let expectedResponse;
+  validateResponse(actualResponse: ActualResponse): ValidationError | null {
+    type ResponseWithSchema = Record<string, { schema: Schema }>;
+    let expectedResponse: ResponseWithSchema;
     try {
-      expectedResponse = this.findExpectedResponse(actualResponse);
+      expectedResponse = this.findExpectedResponse(
+        actualResponse,
+      ) as ResponseWithSchema;
     } catch (error) {
       if (error instanceof ValidationError) {
         return error;
       }
       throw error;
     }
-    const resValidator = new OpenAPIResponseValidator({
+    const validator = new OpenAPIResponseValidator({
       responses: expectedResponse,
       ...this.getComponentDefinitionsProperty(),
     });
 
     const [expectedResStatus] = Object.keys(expectedResponse);
-    const validationError = resValidator.validateResponse(
+    const validationError = validator.validateResponse(
       expectedResStatus,
       actualResponse.getBodyForValidation(),
     );
-    if (validationError) {
-      return new ValidationError(
-        'INVALID_BODY',
-        validationError.errors
-          .map(({ path, message }) => `${path} ${message}`)
-          .join(', '),
-      );
-    }
-    return null;
+    return validationError
+      ? new ValidationError(
+          ErrorCode.InvalidBody,
+          (validationError.errors as { path: string; message: string }[])
+            .map(({ path, message }) => `${path} ${message}`)
+            .join(', '),
+        )
+      : null;
   }
 
   /*
@@ -134,26 +157,30 @@ export default abstract class OpenApiSpec {
    * The 2 mock responses are identical except for the body,
    * thus validating the object against its schema.
    */
-  validateObject(actualObject, schema) {
+  validateObject(
+    actualObject: unknown,
+    schema: Schema,
+  ): ValidationError | null {
     const mockResStatus = 200;
     const mockExpectedResponse = { [mockResStatus]: { schema } };
-    const resValidator = new OpenAPIResponseValidator({
+    const validator = new OpenAPIResponseValidator({
       responses: mockExpectedResponse,
       ...this.getComponentDefinitionsProperty(),
       errorTransformer: ({ path, message }) => ({
         message: `${path.replace('response', 'object')} ${message}`,
       }),
     });
-    const validationError = resValidator.validateResponse(
+    const validationError = validator.validateResponse(
       mockResStatus,
       actualObject,
     );
-    if (validationError) {
-      return new ValidationError(
-        'INVALID_OBJECT',
-        validationError.errors.map((error) => error.message).join(', '),
-      );
-    }
-    return null;
+    return validationError
+      ? new ValidationError(
+          ErrorCode.InvalidObject,
+          (validationError.errors as { message: string }[])
+            .map((error) => error.message)
+            .join(', '),
+        )
+      : null;
   }
 }

--- a/packages/openapi-validator/lib/classes/AbstractResponse.ts
+++ b/packages/openapi-validator/lib/classes/AbstractResponse.ts
@@ -1,27 +1,37 @@
 import { stringify } from '../utils/common.utils';
+import type { RawAxiosResponse } from './AxiosResponse';
+import type { RawRequestPromiseResponse } from './RequestPromiseResponse';
+import type { RawSuperAgentResponse } from './SuperAgentResponse';
 
-export default class AbstractResponse {
-  protected res: any;
+export type RawResponse =
+  | RawAxiosResponse
+  | RawSuperAgentResponse
+  | RawRequestPromiseResponse;
 
-  protected body: any;
+export default abstract class AbstractResponse {
+  public status: number;
 
-  protected status: any;
+  public req: { method: string; path: string };
 
-  protected req: any;
+  public abstract getBodyForValidation(): unknown;
+
+  protected body: unknown;
 
   protected bodyHasNoContent: boolean;
 
-  constructor(res) {
-    this.res = res;
-  }
+  constructor(protected res: RawResponse) {}
 
-  summary(): { body: any; text?: string } {
+  summary(): { body: unknown } {
     return {
       body: this.body,
     };
   }
 
-  toString() {
+  toString(): string {
     return stringify(this.summary());
   }
 }
+
+export type ActualResponse = AbstractResponse;
+
+export type ActualRequest = AbstractResponse['req'];

--- a/packages/openapi-validator/lib/classes/AxiosResponse.ts
+++ b/packages/openapi-validator/lib/classes/AxiosResponse.ts
@@ -1,7 +1,10 @@
+import type { AxiosResponse as AxiosResponseType } from 'axios';
 import AbstractResponse from './AbstractResponse';
 
+export type RawAxiosResponse = AxiosResponseType;
+
 export default class AxiosResponse extends AbstractResponse {
-  constructor(res) {
+  constructor(protected res: RawAxiosResponse) {
     super(res);
     this.status = res.status;
     this.body = res.data;
@@ -9,7 +12,7 @@ export default class AxiosResponse extends AbstractResponse {
     this.bodyHasNoContent = this.body === '';
   }
 
-  getBodyForValidation() {
+  getBodyForValidation(): AxiosResponse['body'] {
     if (this.bodyHasNoContent) {
       return null;
     }

--- a/packages/openapi-validator/lib/classes/OpenApi3Spec.ts
+++ b/packages/openapi-validator/lib/classes/OpenApi3Spec.ts
@@ -1,3 +1,5 @@
+import type { OpenAPIV3 } from 'openapi-types';
+import type { ResponseObject } from './AbstractOpenApiSpec';
 import {
   defaultBasePath,
   findOpenApiPathMatchingPossiblePathnames,
@@ -8,12 +10,12 @@ import {
   getMatchingServerUrlsAndServerBasePaths,
 } from '../utils/OpenApi3Spec.utils';
 import AbstractOpenApiSpec from './AbstractOpenApiSpec';
-import ValidationError from './errors/ValidationError';
+import ValidationError, { ErrorCode } from './errors/ValidationError';
 
 export default class OpenApi3Spec extends AbstractOpenApiSpec {
   public didUserDefineServers: boolean;
 
-  constructor(spec) {
+  constructor(protected spec: OpenAPIV3.Document) {
     super(spec);
     this.didUserDefineServers = !serversPropertyNotProvidedOrIsEmptyArray(spec);
     this.ensureDefaultServer();
@@ -23,41 +25,38 @@ export default class OpenApi3Spec extends AbstractOpenApiSpec {
    * "If the servers property is not provided, or is an empty array, the default value would be a Server Object with a url value of '/'"
    * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields
    */
-  ensureDefaultServer() {
+  ensureDefaultServer(): void {
     if (serversPropertyNotProvidedOrIsEmptyArray(this.spec)) {
       this.spec.servers = [{ url: defaultBasePath }];
     }
   }
 
-  /**
-   * @returns {[ServerObject]} [ServerObject] {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#server-object}
-   */
-  servers() {
+  servers(): OpenAPIV3.ServerObject[] {
     return this.spec.servers;
   }
 
-  getServerUrls() {
+  getServerUrls(): string[] {
     return this.servers().map((server) => server.url);
   }
 
-  getMatchingServerUrls(pathname) {
+  getMatchingServerUrls(pathname: string): string[] {
     return getMatchingServerUrlsAndServerBasePaths(
       this.servers(),
       pathname,
     ).map(({ concreteUrl }) => concreteUrl);
   }
 
-  getMatchingServerBasePaths(pathname) {
+  getMatchingServerBasePaths(pathname: string): string[] {
     return getMatchingServerUrlsAndServerBasePaths(
       this.servers(),
       pathname,
     ).map(({ matchingBasePath }) => matchingBasePath);
   }
 
-  findOpenApiPathMatchingPathname(pathname) {
+  findOpenApiPathMatchingPathname(pathname: string): string {
     const matchingServerBasePaths = this.getMatchingServerBasePaths(pathname);
     if (!matchingServerBasePaths.length) {
-      throw new ValidationError('SERVER_NOT_FOUND');
+      throw new ValidationError(ErrorCode.ServerNotFound);
     }
     const possiblePathnames = matchingServerBasePaths.map((basePath) =>
       getPathnameWithoutBasePath(basePath, pathname),
@@ -67,35 +66,29 @@ export default class OpenApi3Spec extends AbstractOpenApiSpec {
       this.paths(),
     );
     if (!openApiPath) {
-      throw new ValidationError('PATH_NOT_FOUND');
+      throw new ValidationError(ErrorCode.PathNotFound);
     }
     return openApiPath;
   }
 
-  /**
-   * @returns {ResponseObject} ResponseObject
-   * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsResponses}
-   */
-  findResponseDefinition(referenceString) {
+  findResponseDefinition(referenceString: string): ResponseObject {
     const nameOfResponseDefinition = referenceString.split(
       '#/components/responses/',
     )[1];
-    return this.spec.components.responses[nameOfResponseDefinition];
+    return this.spec.components.responses[
+      nameOfResponseDefinition
+    ] as ResponseObject;
   }
 
-  /**
-   * @returns {[ComponentsObject]} ComponentsObject
-   * {@link https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject}
-   */
-  getComponentDefinitions() {
-    return this.spec.components;
+  getComponentDefinitions(): OpenAPIV3.ComponentsObject {
+    return this.spec.components as OpenAPIV3.ComponentsObject;
   }
 
-  getComponentDefinitionsProperty() {
+  getComponentDefinitionsProperty(): Pick<OpenAPIV3.Document, 'components'> {
     return { components: this.getComponentDefinitions() };
   }
 
-  getSchemaObjects() {
+  getSchemaObjects(): OpenAPIV3.ComponentsObject['schemas'] {
     return this.getComponentDefinitions().schemas;
   }
 }

--- a/packages/openapi-validator/lib/classes/RequestPromiseResponse.ts
+++ b/packages/openapi-validator/lib/classes/RequestPromiseResponse.ts
@@ -1,7 +1,15 @@
+import type { Request, Response } from 'request';
 import AbstractResponse from './AbstractResponse';
 
+export type RawRequestPromiseResponse = Response & {
+  req: Request;
+  request: Response['request'] & {
+    _json?: unknown;
+  };
+};
+
 export default class RequestPromiseResponse extends AbstractResponse {
-  constructor(res) {
+  constructor(protected res: RawRequestPromiseResponse) {
     super(res);
     this.status = res.statusCode;
     this.body = res.request._json // eslint-disable-line no-underscore-dangle
@@ -11,12 +19,12 @@ export default class RequestPromiseResponse extends AbstractResponse {
     this.bodyHasNoContent = this.body === '';
   }
 
-  getBodyForValidation() {
+  getBodyForValidation(): RequestPromiseResponse['body'] {
     if (this.bodyHasNoContent) {
       return null;
     }
     try {
-      return JSON.parse(this.body);
+      return JSON.parse(this.body as string);
     } catch (error) {
       // if JSON.parse errors, then body is not stringfied JSON that
       // needs parsing into a JSON object, so just move to the next

--- a/packages/openapi-validator/lib/classes/SuperAgentResponse.ts
+++ b/packages/openapi-validator/lib/classes/SuperAgentResponse.ts
@@ -1,12 +1,17 @@
+import type { Response, SuperAgentRequest } from 'superagent';
 import AbstractResponse from './AbstractResponse';
 
-const isEmptyObj = (obj) =>
+const isEmptyObj = (obj: unknown): obj is Record<string, never> =>
   !!obj && Object.entries(obj).length === 0 && obj.constructor === Object;
+
+export type RawSuperAgentResponse = Response & {
+  req: SuperAgentRequest & { path: string };
+};
 
 export default class SuperAgentResponse extends AbstractResponse {
   private isResTextPopulatedInsteadOfResBody: boolean;
 
-  constructor(res) {
+  constructor(protected res: RawSuperAgentResponse) {
     super(res);
     this.status = res.status;
     this.body = res.body;
@@ -16,7 +21,7 @@ export default class SuperAgentResponse extends AbstractResponse {
     this.bodyHasNoContent = res.text === '';
   }
 
-  getBodyForValidation() {
+  getBodyForValidation(): SuperAgentResponse['body'] {
     if (this.bodyHasNoContent) {
       return null;
     }
@@ -26,11 +31,12 @@ export default class SuperAgentResponse extends AbstractResponse {
     return this.body;
   }
 
-  summary() {
-    const summary = super.summary();
-    if (this.isResTextPopulatedInsteadOfResBody) {
-      summary.text = this.res.text;
-    }
-    return summary;
+  summary(): ReturnType<AbstractResponse['summary']> & {
+    text?: string;
+  } {
+    return {
+      ...super.summary(),
+      ...(this.isResTextPopulatedInsteadOfResBody && { text: this.res.text }),
+    };
   }
 }

--- a/packages/openapi-validator/lib/classes/errors/ValidationError.ts
+++ b/packages/openapi-validator/lib/classes/errors/ValidationError.ts
@@ -1,12 +1,19 @@
-export default class ValidationError extends Error {
-  public code: string;
+export enum ErrorCode {
+  ServerNotFound,
+  BasePathNotFound,
+  PathNotFound,
+  MethodNotFound,
+  StatusNotFound,
+  InvalidBody,
+  InvalidObject,
+}
 
-  constructor(code, message?) {
+export default class ValidationError extends Error {
+  constructor(public code: ErrorCode, message?: string) {
     super(message);
-    this.code = code;
   }
 
-  toString() {
+  toString(): string {
     return this.message;
   }
 }

--- a/packages/openapi-validator/lib/index.ts
+++ b/packages/openapi-validator/lib/index.ts
@@ -1,5 +1,21 @@
+import type { OpenAPI } from 'openapi-types';
+import type OpenApi2Spec from './classes/OpenApi2Spec';
+import type OpenApi3Spec from './classes/OpenApi3Spec';
+
+export type { Schema } from './classes/AbstractOpenApiSpec';
+export type {
+  ActualRequest,
+  ActualResponse,
+  RawResponse,
+} from './classes/AbstractResponse';
 export {
+  default as ValidationError,
   ErrorCode,
 } from './classes/errors/ValidationError';
+export type { default as OpenApi2Spec } from './classes/OpenApi2Spec';
+export type { default as OpenApi3Spec } from './classes/OpenApi3Spec';
 export { default as makeApiSpec } from './openApiSpecFactory';
 export { default as makeResponse } from './responseFactory';
+
+export type OpenApiSpec = OpenApi2Spec | OpenApi3Spec;
+export type OpenAPISpecObject = OpenAPI.Document;

--- a/packages/openapi-validator/lib/index.ts
+++ b/packages/openapi-validator/lib/index.ts
@@ -1,2 +1,5 @@
+export {
+  ErrorCode,
+} from './classes/errors/ValidationError';
 export { default as makeApiSpec } from './openApiSpecFactory';
 export { default as makeResponse } from './responseFactory';

--- a/packages/openapi-validator/lib/index.ts
+++ b/packages/openapi-validator/lib/index.ts
@@ -8,10 +8,8 @@ export type {
   ActualResponse,
   RawResponse,
 } from './classes/AbstractResponse';
-export {
-  default as ValidationError,
-  ErrorCode,
-} from './classes/errors/ValidationError';
+export type { default as ValidationError } from './classes/errors/ValidationError';
+export { ErrorCode } from './classes/errors/ValidationError';
 export type { default as OpenApi2Spec } from './classes/OpenApi2Spec';
 export type { default as OpenApi3Spec } from './classes/OpenApi3Spec';
 export { default as makeApiSpec } from './openApiSpecFactory';

--- a/packages/openapi-validator/lib/openApiSpecFactory.ts
+++ b/packages/openapi-validator/lib/openApiSpecFactory.ts
@@ -3,6 +3,7 @@ import yaml from 'js-yaml';
 import OpenAPISchemaValidator from 'openapi-schema-validator';
 import type { OpenAPI, OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import path from 'path';
+import typeOf from 'typeof';
 import OpenApi2Spec from './classes/OpenApi2Spec';
 import OpenApi3Spec from './classes/OpenApi3Spec';
 import { stringify } from './utils/common.utils';
@@ -32,12 +33,10 @@ function loadSpec(arg: unknown): AnyObject {
     if (isObject(arg)) {
       return arg;
     }
-    throw new Error();
+    throw new Error(`Received type '${typeOf(arg)}'`);
   } catch (error) {
     throw new Error(
-      `The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.${
-        error.message ? `\nError: ${error.message}` : ''
-      }`,
+      `The provided argument must be either an absolute filepath or an object representing an OpenAPI specification.\nError details: ${error.message}`,
     );
   }
 }

--- a/packages/openapi-validator/lib/responseFactory.ts
+++ b/packages/openapi-validator/lib/responseFactory.ts
@@ -1,12 +1,15 @@
+import { RawResponse } from './classes/AbstractResponse';
 import AxiosResponse from './classes/AxiosResponse';
-import SuperAgentResponse from './classes/SuperAgentResponse';
 import RequestPromiseResponse from './classes/RequestPromiseResponse';
+import SuperAgentResponse from './classes/SuperAgentResponse';
 
-export default function makeResponse(res) {
-  if (Object.prototype.hasOwnProperty.call(res, 'data')) {
+export default function makeResponse(
+  res: RawResponse,
+): AxiosResponse | SuperAgentResponse | RequestPromiseResponse {
+  if ('data' in res) {
     return new AxiosResponse(res);
   }
-  if (Object.prototype.hasOwnProperty.call(res, 'status')) {
+  if ('status' in res) {
     return new SuperAgentResponse(res);
   }
   return new RequestPromiseResponse(res);

--- a/packages/openapi-validator/lib/utils/combos.d.ts
+++ b/packages/openapi-validator/lib/utils/combos.d.ts
@@ -1,0 +1,7 @@
+declare module 'combos' {
+  const combos: <Key, Value>(
+    keysToPossibleValues: Record<Key, Value[]>,
+  ) => Record<Key, Value>[];
+
+  export default combos;
+}

--- a/packages/openapi-validator/lib/utils/common.utils.ts
+++ b/packages/openapi-validator/lib/utils/common.utils.ts
@@ -1,30 +1,43 @@
-import { inspect } from 'util';
 import { Path } from 'path-parser';
 import url from 'url';
+import { inspect } from 'util';
+import type { ActualRequest } from '../classes/AbstractResponse';
 
-export const stringify = (obj) => inspect(obj, { depth: null });
+export const stringify = (obj: unknown): string =>
+  inspect(obj, { depth: null });
 
-// excludes the query because path = pathname + query
-export const getPathname = (request) => url.parse(request.path).pathname;
+/**
+ * Excludes the query because path = pathname + query
+ */
+export const getPathname = (request: ActualRequest): string =>
+  url.parse(request.path).pathname;
 
-// converts all {foo} to :foo
-const convertOpenApiPathToColonForm = (openApiPath) =>
+/**
+ * Converts all {foo} to :foo
+ */
+const convertOpenApiPathToColonForm = (openApiPath: string): string =>
   openApiPath.replace(/{/g, ':').replace(/}/g, '');
 
-const doesColonPathMatchPathname = (pathInColonForm, pathname) => {
+const doesColonPathMatchPathname = (
+  pathInColonForm: string,
+  pathname: string,
+): boolean => {
   const pathParamsInPathname = new Path(pathInColonForm).test(pathname); // => one of: null, {}, {exampleParam: 'foo'}
   return Boolean(pathParamsInPathname);
 };
 
-const doesOpenApiPathMatchPathname = (openApiPath, pathname) => {
+const doesOpenApiPathMatchPathname = (
+  openApiPath: string,
+  pathname: string,
+): boolean => {
   const pathInColonForm = convertOpenApiPathToColonForm(openApiPath);
   return doesColonPathMatchPathname(pathInColonForm, pathname);
 };
 
 export const findOpenApiPathMatchingPossiblePathnames = (
-  possiblePathnames,
-  OAPaths,
-) => {
+  possiblePathnames: string[],
+  OAPaths: string[],
+): string => {
   let openApiPath;
   // eslint-disable-next-line no-restricted-syntax
   for (const pathname of possiblePathnames) {
@@ -43,5 +56,8 @@ export const findOpenApiPathMatchingPossiblePathnames = (
 
 export const defaultBasePath = '/';
 
-export const getPathnameWithoutBasePath = (basePath, pathname) =>
+export const getPathnameWithoutBasePath = (
+  basePath: string,
+  pathname: string,
+): string =>
   basePath === defaultBasePath ? pathname : pathname.replace(basePath, '');

--- a/packages/openapi-validator/package.json
+++ b/packages/openapi-validator/package.json
@@ -42,13 +42,15 @@
     "js-yaml": "^4.0.0",
     "openapi-response-validator": "^9.2.0",
     "openapi-schema-validator": "^9.2.0",
-    "path-parser": "^6.1.0"
+    "path-parser": "^6.1.0",
+    "typeof": "^1.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",
     "@types/js-yaml": "^4.0.3",
     "@types/request": "^2.48.7",
     "@types/superagent": "^4.1.12",
+    "@types/typeof": "^1.0.0",
     "openapi-types": "^9.2.0"
   }
 }

--- a/packages/openapi-validator/package.json
+++ b/packages/openapi-validator/package.json
@@ -42,7 +42,13 @@
     "js-yaml": "^4.0.0",
     "openapi-response-validator": "^9.2.0",
     "openapi-schema-validator": "^9.2.0",
-    "path-parser": "^6.1.0",
-    "typeof": "^1.0.0"
+    "path-parser": "^6.1.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.12",
+    "@types/js-yaml": "^4.0.3",
+    "@types/request": "^2.48.7",
+    "@types/superagent": "^4.1.12",
+    "openapi-types": "^9.2.0"
   }
 }

--- a/packages/openapi-validator/package.json
+++ b/packages/openapi-validator/package.json
@@ -40,8 +40,8 @@
     "combos": "^0.2.0",
     "fs-extra": "^9.0.0",
     "js-yaml": "^4.0.0",
-    "openapi-response-validator": "^7.4.0",
-    "openapi-schema-validator": "^7.2.3",
+    "openapi-response-validator": "^9.2.0",
+    "openapi-schema-validator": "^9.2.0",
     "path-parser": "^6.1.0",
     "typeof": "^1.0.0"
   }

--- a/packages/openapi-validator/tsconfig.json
+++ b/packages/openapi-validator/tsconfig.json
@@ -16,7 +16,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "dist" /* Redirect output structure to the directory. */
+    "outDir": "dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -28,7 +28,7 @@
 
     /* Strict Type-Checking Options */
     // "strict": true,                        /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.1.0":
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.0.tgz#674a40325eab23c857ebc0689e7e191a3c5b10cc"
+  integrity sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@lerna/add@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-4.0.0.tgz#c36f57d132502a57b9e7058d1548b7a565ef183f"
@@ -1506,13 +1517,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.20":
-  version "26.0.20"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
-  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+"@types/jest@^27.0.1":
+  version "27.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.1.tgz#fafcc997da0135865311bb1215ba16dba6bdf4ca"
+  integrity sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==
   dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
+    jest-diff "^27.0.0"
+    pretty-format "^27.0.0"
 
 "@types/js-yaml@^4.0.3":
   version "4.0.3"
@@ -1946,6 +1957,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -3151,6 +3167,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.0.6:
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
+  integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
 diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
@@ -5099,7 +5120,7 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-diff@^26.0.0, jest-diff@^26.6.2:
+jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -5108,6 +5129,16 @@ jest-diff@^26.0.0, jest-diff@^26.6.2:
     diff-sequences "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-diff@^27.0.0:
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.1.0.tgz#c7033f25add95e2218f3c7f4c3d7b634ab6b3cd2"
+  integrity sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.0.6"
+    jest-get-type "^27.0.6"
+    pretty-format "^27.1.0"
 
 jest-docblock@^26.0.0:
   version "26.0.0"
@@ -5156,6 +5187,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.0.6:
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
+  integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -7083,7 +7119,7 @@ prettier@^2.1.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
-pretty-format@^26.0.0, pretty-format@^26.6.2:
+pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -7091,6 +7127,16 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.0, pretty-format@^27.1.0:
+  version "27.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.1.0.tgz#022f3fdb19121e0a2612f3cff8d724431461b9ca"
+  integrity sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==
+  dependencies:
+    "@jest/types" "^27.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 process-nextick-args@~2.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,6 +1611,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.1.tgz#8f80dd965ad81f3e1bc26d6f5c727e132721ff40"
   integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
 
+"@types/typeof@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/typeof/-/typeof-1.0.0.tgz#cb22645285af4ff33c00e85ebe4eebdeff5480c0"
+  integrity sha512-Qv/U8q1Gnw8czN6Q09ZCm4UdU+/QF7wMy83svkRmRDnW9WX1utFK4QkaXqsKx2vAJTSUrbYErZPSRkP3812Hyw==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -8741,6 +8746,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typeof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typeof/-/typeof-1.0.0.tgz#9c84403f2323ae5399167275497638ea1d2f2440"
+  integrity sha1-nIRAPyMjrlOZFnJ1SXY46h0vJEA=
 
 typescript@^4.2.3:
   version "4.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,7 +1821,14 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.5.2, ajv@^6.5.4, ajv@^6.5.5:
+ajv-formats@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.5.5:
   version "6.12.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
   integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
@@ -1829,6 +1836,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.5.2, ajv@^6.5.4, ajv@^6.5.5:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.1.0, ajv@^8.4.0:
+  version "8.6.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
+  integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-colors@4.1.1:
@@ -5433,6 +5450,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -6544,28 +6566,28 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-openapi-response-validator@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/openapi-response-validator/-/openapi-response-validator-7.4.0.tgz#4de7dab639fb78dc4ef3ca8e60f7c7e1d42ceb8f"
-  integrity sha512-Su8jA45PhegUgJnEAT15DYt2spPJgvjyTtXqg+Lw5AtGePfcQskV6ACEzsL0XPoAXIFf09Vx6sBor9pek+tl+Q==
+openapi-response-validator@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/openapi-response-validator/-/openapi-response-validator-9.2.0.tgz#5329b1931c13c464a0ead1860dca428ca9cc4a09"
+  integrity sha512-1MmOeq1iV/BIoahJ6wVM02KehV7Ab9vB3n64zPqYVIJOE8ilDBhCU6/YAm69YciMuWW9+Xc/qvcbKihjxZNp5A==
   dependencies:
-    ajv "^6.5.4"
-    openapi-types "^7.2.3"
+    ajv "^8.4.0"
+    openapi-types "^9.2.0"
 
-openapi-schema-validator@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/openapi-schema-validator/-/openapi-schema-validator-7.2.3.tgz#05f79a3cc5668882a85a272b61895e4ccfc6eefb"
-  integrity sha512-XT8NM5e/zBBa/cydTS1IeYkCPzJp9oixvt9Y1lEx+2gsCTOooNxw9x/KEivtWMSokne7X1aR+VtsYHQtNNOSyA==
+openapi-schema-validator@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/openapi-schema-validator/-/openapi-schema-validator-9.2.0.tgz#5076b8de2a87f2bfbe5e040db9d2b45d632007f4"
+  integrity sha512-BzXm4Kz78pw9BMxW2whd9nKnYjLFxqFWEkH8Eh1/bZ2aOeCfIgPkYvU9Ai/fAPNQAW0y+oDSl1BoqGKENlO6sA==
   dependencies:
-    ajv "^6.5.2"
+    ajv "^8.1.0"
+    ajv-formats "^2.0.2"
     lodash.merge "^4.6.1"
-    openapi-types "^7.2.3"
-    swagger-schema-official "2.0.0-bab6bed"
+    openapi-types "^9.2.0"
 
-openapi-types@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-7.2.3.tgz#83829911a3410a022f0e0cf2b0b2e67232ccf96e"
-  integrity sha512-olbaNxz12R27+mTyJ/ZAFEfUruauHH27AkeQHDHRq5AF0LdNkK1SSV7EourXQDK+4aX7dv2HtyirAGK06WMAsA==
+openapi-types@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-9.2.0.tgz#db50b38398b2ed7116cfa08fc7296d68528dbee2"
+  integrity sha512-3x0gg8DxhpZ5MVki7AK6jmMdVIZASmVGo9CoUtD+nksLdkqz7EzWKdfS9Oxxq1J7idnZV0b3LjqcvizfKFySpQ==
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -7469,6 +7491,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -8266,11 +8293,6 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
-
-swagger-schema-official@2.0.0-bab6bed:
-  version "2.0.0-bab6bed"
-  resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz#70070468d6d2977ca5237b2e519ca7d06a2ea3fd"
-  integrity sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=
 
 symbol-tree@^3.2.4:
   version "3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
 "@types/chai@4":
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.11.tgz#d3614d6c5f500142358e6ed24e1bf16657536c50"
@@ -1467,6 +1472,13 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
   integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
+
+"@types/fs-extra@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.12.tgz#9b8f27973df8a7a3920e8461517ebf8a7d4fdfaf"
+  integrity sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
@@ -1501,6 +1513,11 @@
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
+
+"@types/js-yaml@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.3.tgz#9f33cd6fbf0d5ec575dc8c8fc69c7fec1b4eb200"
+  integrity sha512-5t9BhoORasuF5uCPr+d5/hdB++zRFUTMIZOzbNkr+jZh3yQht4HYbRDyj9fY8n2TZT30iW9huzav73x4NikqWg==
 
 "@types/json-schema@^7.0.3":
   version "7.0.4"
@@ -1547,6 +1564,16 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d"
   integrity sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
 
+"@types/request@^2.48.7":
+  version "2.48.7"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.7.tgz#a962d11a26e0d71d9a9913d96bb806dc4d4c2f19"
+  integrity sha512-GWP9AZW7foLd4YQxyFZDBepl0lPsWLMEXDZUjQ/c1gqVPDPECrRZyEzuhJdnPWioFCq3Tv0qoGpMD6U+ygd4ZA==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -1560,6 +1587,19 @@
     "@types/cookiejar" "*"
     "@types/node" "*"
 
+"@types/superagent@^4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.12.tgz#fad68c6712936892ad24cf94f2f7a07cc749fd0f"
+  integrity sha512-1GQvD6sySQPD6p9EopDFI3f5OogdICl1sU/2ij3Esobz/RtL9fWZZDPmsuv7eiy5ya+XNiPAxUcI3HIUTJa+3A==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
+
+"@types/tough-cookie@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.1.tgz#8f80dd965ad81f3e1bc26d6f5c727e132721ff40"
+  integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -1569,6 +1609,13 @@
   version "15.0.4"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
   integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3902,7 +3949,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.3.1:
+form-data@^2.3.1, form-data@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
@@ -8648,11 +8695,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typeof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typeof/-/typeof-1.0.0.tgz#9c84403f2323ae5399167275497638ea1d2f2440"
-  integrity sha1-nIRAPyMjrlOZFnJ1SXY46h0vJEA=
 
 typescript@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
* feat: add Typescript hints for the `filepathOrObject` arg

* refactor: much stricter internal use of TypeScript

* BREAKING CHANGE: this updates [our validation dependency](https://www.npmjs.com/package/openapi-response-validator) by 2 major versions, so validation error messages (and maybe validation rules) are slightly different. For example, `res did not satisfy it because: property1 should be string, property2 should be string` is now `res did not satisfy it because: property1 must be string, property2 must be string` (`should` -> `must`). We expect our users to _read_ these error messages during testing but not assert on them, such that this change shouldn't break anyone's existing tests. Moreover, renaming `should` to `must` does not indicate that the validation rule has changed. **However, it is possible that _other_ validation rules have changed**