### PR TITLE
fix: move `@types/request` and `@types/superagent` to `dependencies`

### DIFF
--- a/packages/openapi-validator/package.json
+++ b/packages/openapi-validator/package.json
@@ -37,6 +37,8 @@
     "dist"
   ],
   "dependencies": {
+    "@types/request": "^2.48.7",
+    "@types/superagent": "^4.1.12",
     "combos": "^0.2.0",
     "fs-extra": "^9.0.0",
     "js-yaml": "^4.0.0",
@@ -48,8 +50,6 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",
     "@types/js-yaml": "^4.0.3",
-    "@types/request": "^2.48.7",
-    "@types/superagent": "^4.1.12",
     "@types/typeof": "^1.0.0",
     "openapi-types": "^9.2.0"
   }


### PR DESCRIPTION
fixes #258 